### PR TITLE
Fix a bug when HTML contains multibyte characters

### DIFF
--- a/tasks/reload.js
+++ b/tasks/reload.js
@@ -139,7 +139,12 @@ module.exports = function (grunt) {
                                     var html = tmpBuffer.toString();
 
                                     html = html.replace('</body>', reloadClientMarkup + '</body>');
-                                    _headers['content-length'] = html.length;
+
+                                    // since nodejs only support few charsets, we only support
+                                    // UTF-8 at this moment.
+                                    // TODO: support other charsets besides UTF-8
+                                    _headers['content-length'] = Buffer.byteLength(html, 'utf-8');
+
                                     _writeHead.call(res, _statusCode, _headers);
                                     _write.call(res, html);
                                 }


### PR DESCRIPTION
Given HTML like this:

```
<body>中文字符中文字符中文字符中文字符中文字符中文字符</body>
```

The entire output HTML of reload server will be:

```
<body>中文字符中文字符中文字符中文字符中文字符中文字符
```

There are some characters missing because of the byte length counting method.
I have modified `tasks/reload.js` to support UTF-8 charset files.
Please make a review at this, thanks! 
