### PR TITLE
Compatibility for grunt 0.4.0 (fixes #13)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-'use strict';
+    'use strict';
 
 module.exports = function (grunt) {
 
@@ -14,22 +14,33 @@ module.exports = function (grunt) {
             all: ['http://localhost:8000/test/qunit.html']
         },
         reload: {
-            proxy: {}
+            proxy: {},
+            liveReload: {}
         },
         server: {
             port: 8000
+        },
+        connect: {
+            dev: {
+                options: {
+                    port: 8000,
+                }
+            }
         },
         trigger: {
             watchFile: 'test/trigger.html'
         },
         watch: {
+            options: {
+                interrupt: true
+            },
             'default': {
                 files: ['<config:lint.files>'],
                 tasks: 'lint reload'
             },
             triggerTest: {
                 files: ['test/trigger.html'],
-                tasks: 'reload trigger'
+                tasks: 'reload'
             }
         },
         jshint: {
@@ -53,11 +64,14 @@ module.exports = function (grunt) {
         }
     });
 
+    grunt.loadNpmTasks('grunt-contrib-connect');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+
     // Load local tasks.
     grunt.loadTasks('tasks');
     grunt.loadTasks('test/tasks');
 
     grunt.registerTask('default', 'server reload watch:default');
-    grunt.registerTask('triggerTest', 'server reload watch:triggerTest');
+    grunt.registerTask('triggerTest', ['connect:dev', 'reload', 'watch:triggerTest']);
 
 };

--- a/package.json
+++ b/package.json
@@ -30,17 +30,21 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt": ">=0.3.9",
+    "grunt": "0.4.0rc4",
     "connect": "~2.3.0",
     "buffers": "0.1.1",
     "http-proxy": "0.8.0",
     "websocket": "~1.0.6"
   },
   "devDependencies": {
-    "grunt": ">=0.3.9",
-    "grunt-less": "latest"
+    "grunt": "0.4.0rc4",
+    "grunt-contrib-watch": "~0.2.0a",
+    "grunt-less": "latest",
+    "grunt-contrib-connect": "0.1.0",
+    "request": "~2.12.0"
   },
   "keywords": [
-    "gruntplugin", "reload"
+    "gruntplugin",
+    "reload"
   ]
 }

--- a/tasks/reload.js
+++ b/tasks/reload.js
@@ -20,6 +20,7 @@ module.exports = function (grunt) {
     var buffers = require('buffers');
     var httpProxy = require('http-proxy');
     var WebSocketServer = require("websocket").server;
+    var request = require('request');
 
     var throttle = false;
     // support for multiple reload servers
@@ -52,10 +53,8 @@ module.exports = function (grunt) {
         };
     }
 
-    grunt.registerTask('reload', "Reload connected clients when a file has changed.", function (target) {
-
+    function startServer(target) {
         var server = servers[target ? target:'default'];
-
         if (server) {
             var errorcount = grunt.fail.errorcount;
             // throttle was needed early in development because of rapid triggering by the watch task. Not sure if it's still necessary
@@ -179,6 +178,11 @@ module.exports = function (grunt) {
                 fs.createReadStream(__dirname + "/include/reloadClient.js").pipe(res); // use connect.static.send ?
             }));
 
+            middleware.unshift(route('GET', '/triggerReload', function (req, res, next) {
+                taskEvent.emit('reload');
+                res.end("triggered");
+            }));
+
             // if --debug was specified, enable logging.
             if (grunt.option('debug')) {
                 connect.logger.format('grunt', ('[D] reloadServer :method :url :status ' +
@@ -241,7 +245,28 @@ module.exports = function (grunt) {
             }
 
             grunt.log.writeln("reload server running at http://localhost:" + port);
-
         }
+
+    };
+
+    grunt.registerTask('reload', "Reload connected clients when a file has changed.", function (target) {
+        var done = this.async();
+        var that = this;
+        this.requiresConfig('reload');
+
+        // Get values from config, or use defaults.
+        var config = target ? grunt.config(['reload', target]) : grunt.config('reload');
+        var port = config.port || 8001;
+        request('http://localhost:'+port+'/triggerReload', function (error, response, body) {
+            if (!error && response.statusCode == 200) {
+                // Reload was triggered successfully
+                grunt.log.writeln("Triggered reload in running reload-server");
+            } else {
+                // Server doesn't seem to be running, start our own
+                startServer.call(that,target);
+            }
+            done();
+        });
+
     });
 };

--- a/tasks/reload.js
+++ b/tasks/reload.js
@@ -178,9 +178,10 @@ module.exports = function (grunt) {
                 fs.createReadStream(__dirname + "/include/reloadClient.js").pipe(res); // use connect.static.send ?
             }));
 
+            // route to trigger reload
             middleware.unshift(route('GET', '/triggerReload', function (req, res, next) {
                 taskEvent.emit('reload');
-                res.end("triggered");
+                res.end("reload triggered");
             }));
 
             // if --debug was specified, enable logging.
@@ -257,6 +258,7 @@ module.exports = function (grunt) {
         // Get values from config, or use defaults.
         var config = target ? grunt.config(['reload', target]) : grunt.config('reload');
         var port = config.port || 8001;
+        // First, try to trigger reload in already running server process
         request('http://localhost:'+port+'/triggerReload', function (error, response, body) {
             if (!error && response.statusCode == 200) {
                 // Reload was triggered successfully

--- a/test/tasks/trigger.js
+++ b/test/tasks/trigger.js
@@ -10,12 +10,18 @@
 
 module.exports = function (grunt) {
 
+    // can be called from client via reloadServer
+    var trigger = function (path) {
+        var html = grunt.file.read(path).replace(/<h1>(.*)<\/h1>/, '<h1>' + new Date() + '</h1>');
+        grunt.file.write(path, html);
+    };
+
     grunt.registerTask('trigger', 'Write timestamp to html file in order to trigger watch task.', function (data, name) {
         var errorcount = grunt.fail.errorcount;
         var updatedFile = grunt.config('trigger.watchFile');
 
         setTimeout(function () {
-            grunt.helper('trigger', updatedFile);
+            trigger('updatedFile');
         }, 5000);
 
         grunt.log.writeln("Trigger task triggered. Writing to " + updatedFile + ' ');
@@ -26,10 +32,5 @@ module.exports = function (grunt) {
         }
     });
 
-    // can be called from client via reloadServer
-    grunt.registerHelper('trigger', function (path) {
-        var html = grunt.file.read(path).replace(/<h1>(.*)<\/h1>/, '<h1>' + new Date() + '</h1>');
-        grunt.file.write(path, html);
-    });
 
 };


### PR DESCRIPTION
Added some compatibility fixes for grunt 0.4.0.

Besides updating the gruntfile for 0.4.0, added a mechanism that triggers reloads via a HTTP request, which addresses the issue of grunt-watch now spawning tasks in their own process (see #13).

If you need any other changes, please let me know. Cheers!
