### PR TITLE
request module as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
     "connect": "~2.3.0",
     "buffers": "0.1.1",
     "http-proxy": "0.8.0",
-    "websocket": "~1.0.8"
+    "websocket": "~1.0.8",
+    "request": "~2.12.0"
   },
   "devDependencies": {
     "grunt": "0.4.0rc4",
     "grunt-contrib-watch": "~0.2.0a",
     "grunt-contrib-less": "latest",
     "grunt-contrib-connect": "0.1.0",
-    "grunt-contrib-jshint": "0.1.1rc5",
-    "request": "~2.12.0"
+    "grunt-contrib-jshint": "0.1.1rc5"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
The request module should be defined as a dependency rather than a devDependency. This fixes "Error: Cannot find module 'request'" message.
