### PR TITLE
Don't die without grunt-connect

### DIFF
--- a/tasks/reload.js
+++ b/tasks/reload.js
@@ -70,7 +70,8 @@ module.exports = function (grunt) {
 
         if (config.proxy) {
             var proxyConfig = config.proxy;
-            var connectOpts = grunt.config(['connect', target]).options;
+            var connectConfig = grunt.config(['connect', target]);
+            var connectOpts = connectConfig && connectConfig.options;
             var proxyOpts = {
                 target:{
                     host:proxyConfig.host || 'localhost',


### PR DESCRIPTION
Hi Matt.

This little fix should prevent proxy initialisation code from throwing `NullReference` when there is no config section for _grunt-contrib-connect_.

Found this bug when using grunt with custom server task and `grunt-reload` with _proxy_ method enabled.

PS: Thanks for the plugin.

Regards,
Yury.
